### PR TITLE
Open connection before Async operations

### DIFF
--- a/Dapper.GraphQL.Test/InsertTests.cs
+++ b/Dapper.GraphQL.Test/InsertTests.cs
@@ -101,7 +101,7 @@ namespace Dapper.GraphQL.Test
             int personId;
             using (var db = fixture.GetDbConnection())
             {
-                // db.Open();
+                db.Open();
 
                 personId = await SqlBuilder
                     .Insert(person)
@@ -127,7 +127,7 @@ namespace Dapper.GraphQL.Test
             int insertedCount;
             using (var db = fixture.GetDbConnection())
             {
-                // db.Open();
+                db.Open();
 
                 insertedCount = await SqlBuilder
                     .Insert(email)


### PR DESCRIPTION
As per [conversation with Dapper team](https://github.com/StackExchange/Dapper/issues/757) that they'll still be extending off IDbConnection (at least for now) and will cast to DbConnection if connection needs to open but will be returning better messaging.

