### PR TITLE
Add non-generic versions of service registration methods

### DIFF
--- a/Dapper.GraphQL/DapperGraphQLOptions.cs
+++ b/Dapper.GraphQL/DapperGraphQLOptions.cs
@@ -31,6 +31,12 @@ namespace Dapper.GraphQL
             return this;
         }
 
+        /// <summary>
+        /// Adds a GraphQL query builder to the container.
+        /// </summary>
+        /// <param name="modelType">The model type to be queried.</param>
+        /// <param name="queryBuilderType">The query builder class, must implement IQueryBuilder<modelType></param>
+        /// <returns>The GraphQLOptions object.</returns>
         public DapperGraphQLOptions AddQueryBuilder(Type modelType, Type queryBuilderType)
         {
             var queryBuilderInterface = typeof(IQueryBuilder<>).MakeGenericType(modelType);
@@ -54,6 +60,11 @@ namespace Dapper.GraphQL
             return this;
         }
 
+        /// <summary>
+        /// Adds a GraphQL schema to the container.
+        /// </summary>
+        /// <param name="graphSchemaType">The schema type to be mapped, must implement ISchema.</param>
+        /// <returns>The GraphQLOptions object.</returns>
         public DapperGraphQLOptions AddSchema(Type graphSchemaType)
         {
             if (!graphSchemaType.IsConcrete() || !typeof(ISchema).IsAssignableFrom(graphSchemaType))
@@ -76,6 +87,11 @@ namespace Dapper.GraphQL
             return this;
         }
 
+        /// <summary>
+        /// Adds a GraphQL type to the container.
+        /// </summary>
+        /// <param name="type">The model type to be mapped, must implement IGraphType.</param>
+        /// <returns>The GraphQLOptions object.</returns>
         public DapperGraphQLOptions AddType(Type type)
         {
             if (!type.IsConcrete() || !typeof(IGraphType).IsAssignableFrom(type))


### PR DESCRIPTION
When configuring in an automatic fashion (scanning an assembly for `IQueryBuilder` implementations and adding each one), using the generic methods is not really convenient.

This PR adds registration methods which accept straight forward `Type` arguments, which I believe is a common convention in other libraries.

I am happy to add documentation for the new methods if this PR seems ok in other aspects. 