### PR TITLE
Add SqlOptions to set command timeout, type etc.

### DIFF
--- a/Dapper.GraphQL/Contexts/SqlDeleteContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlDeleteContext.cs
@@ -52,10 +52,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             int result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
@@ -72,10 +73,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);

--- a/Dapper.GraphQL/Contexts/SqlDeleteContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlDeleteContext.cs
@@ -52,13 +52,17 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null)
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            int result = connection.Execute(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            int result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             if (Deletes != null)
             {
                 // Execute each delete and aggregate the results
-                result = Deletes.Aggregate(result, (current, delete) => current + delete.Execute(connection, transaction));
+                result = Deletes.Aggregate(result, (current, delete) => current + delete.Execute(connection, transaction, options));
             }
             return result;
         }
@@ -68,13 +72,17 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null)
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             if (Deletes != null)
             {
                 // Execute each delete and aggregate the results
-                result = await Deletes.AggregateAsync(result, async (current, delete) => current + await delete.ExecuteAsync(connection, transaction));
+                result = await Deletes.AggregateAsync(result, async (current, delete) => current + await delete.ExecuteAsync(connection, transaction, options));
             }
             return result;
         }

--- a/Dapper.GraphQL/Contexts/SqlInsertContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlInsertContext.cs
@@ -60,13 +60,17 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null)
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            int result = connection.Execute(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            int result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             if (Inserts != null)
             {
                 // Execute each insert and aggregate the results
-                result = Inserts.Aggregate(result, (current, insert) => current + insert.Execute(connection, transaction));
+                result = Inserts.Aggregate(result, (current, insert) => current + insert.Execute(connection, transaction, options));
             }
             return result;
         }
@@ -76,13 +80,17 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null)
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             if (Inserts != null)
             {
                 // Execute each insert and aggregate the results
-                result = await Inserts.AggregateAsync(result, async (current, insert) => current + await insert.ExecuteAsync(connection, transaction));
+                result = await Inserts.AggregateAsync(result, async (current, insert) => current + await insert.ExecuteAsync(connection, transaction, options));
             }
             return result;
         }

--- a/Dapper.GraphQL/Contexts/SqlInsertContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlInsertContext.cs
@@ -60,10 +60,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             int result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
@@ -80,10 +81,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             int result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);

--- a/Dapper.GraphQL/Contexts/SqlQueryContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlQueryContext.cs
@@ -105,9 +105,14 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
             IDbConnection connection,
             IHaveSelectionSet selectionSet,
             IEntityMapper<TEntityType> mapper = null,
-            IDbTransaction transaction = null)
+            IDbTransaction transaction = null,
+            SqlOptions options = null)
             where TEntityType : class
         {
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
             if (mapper == null)
             {
                 mapper = new EntityMapper<TEntityType>();
@@ -134,7 +139,10 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
                 param: this.Parameters,
                 map: fn,
                 splitOn: string.Join(",", this._splitOn),
-                transaction: transaction
+                transaction: transaction,
+                commandTimeout: options.CommandTimeout,
+                commandType: options.CommandType,
+                buffered: options.Buffered
             );
             return results.Where(e => e != null);
         }
@@ -171,9 +179,14 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
             IDbConnection connection, 
             IHaveSelectionSet selectionSet,
             IEntityMapper<TEntityType> mapper = null,
-            IDbTransaction transaction = null)
+            IDbTransaction transaction = null,
+            SqlOptions options = null)
             where TEntityType : class
         {
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
             if (mapper == null)
             {
                 mapper = new EntityMapper<TEntityType>();
@@ -200,7 +213,10 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
                 param: this.Parameters,
                 map: fn,
                 splitOn: string.Join(",", this._splitOn),
-                transaction: transaction
+                transaction: transaction,
+                commandTimeout: options.CommandTimeout,
+                commandType: options.CommandType,
+                buffered: options.Buffered
             );
             return results.Where(e => e != null);
         }

--- a/Dapper.GraphQL/Contexts/SqlQueryContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlQueryContext.cs
@@ -100,17 +100,18 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
         /// <param name="mapper">The entity mapper.</param>
         /// <param name="selectionSet">The GraphQL selection set (optional).</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
+        /// <param name="options">The options for the query (optional).</param>
         /// <returns>A list of entities returned by the query.</returns>
         public IEnumerable<TEntityType> Execute<TEntityType>(
             IDbConnection connection,
             IHaveSelectionSet selectionSet,
             IEntityMapper<TEntityType> mapper = null,
             IDbTransaction transaction = null,
-            SqlOptions options = null)
+            SqlMapperOptions options = null)
             where TEntityType : class
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             if (mapper == null)
@@ -174,17 +175,18 @@ FROM {from}/**innerjoin**//**leftjoin**//**rightjoin**//**join**/
         /// <param name="mapper">The entity mapper.</param>
         /// <param name="selectionSet">The GraphQL selection set (optional).</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
+        /// <param name="options">The options for the query (optional).</param>
         /// <returns>A list of entities returned by the query.</returns>
         public async Task<IEnumerable<TEntityType>> ExecuteAsync<TEntityType>(
             IDbConnection connection, 
             IHaveSelectionSet selectionSet,
             IEntityMapper<TEntityType> mapper = null,
             IDbTransaction transaction = null,
-            SqlOptions options = null)
+            SqlMapperOptions options = null)
             where TEntityType : class
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             if (mapper == null)

--- a/Dapper.GraphQL/Contexts/SqlUpdateContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlUpdateContext.cs
@@ -78,10 +78,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             var result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
@@ -93,10 +94,11 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
+        /// <param name="options">The options for the command (optional).</param>
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlMapperOptions options = null)
         {
             if (options == null) {
-                options = SqlOptions.DefaultOptions;
+                options = SqlMapperOptions.DefaultOptions;
             }
 
             var result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);

--- a/Dapper.GraphQL/Contexts/SqlUpdateContext.cs
+++ b/Dapper.GraphQL/Contexts/SqlUpdateContext.cs
@@ -78,9 +78,13 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public int Execute(IDbConnection connection, IDbTransaction transaction = null)
+        public int Execute(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            var result = connection.Execute(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            var result = connection.Execute(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             return result;
         }
 
@@ -89,9 +93,13 @@ namespace Dapper.GraphQL
         /// </summary>
         /// <param name="connection">The database connection.</param>
         /// <param name="transaction">The transaction to execute under (optional).</param>
-        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null)
+        public async Task<int> ExecuteAsync(IDbConnection connection, IDbTransaction transaction = null, SqlOptions options = null)
         {
-            var result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction);
+            if (options == null) {
+                options = SqlOptions.DefaultOptions;
+            }
+
+            var result = await connection.ExecuteAsync(BuildSql(), Parameters, transaction, options.CommandTimeout, options.CommandType);
             return result;
         }
 

--- a/Dapper.GraphQL/SqlOptions.cs
+++ b/Dapper.GraphQL/SqlOptions.cs
@@ -2,13 +2,30 @@ using System.Data;
 
 namespace Dapper.GraphQL
 {
-    public class SqlOptions {
-        public static readonly SqlOptions DefaultOptions = new SqlOptions();
+    /// <summary>
+    /// Options for database queries and commands.
+    /// These options corresponds to the optional parameters used by
+    /// Dapper's SqlMapper class.
+    /// </summary>
+    public class SqlMapperOptions {
+        /// <summary>
+        /// The default options used unless other are specified.
+        /// </summary>
+        public static readonly SqlMapperOptions DefaultOptions = new SqlMapperOptions();
 
+        /// <summary>
+        /// Number of seconds before command execution timeout.
+        /// </summary>
         public int? CommandTimeout { get; set; }
 
+        /// <summary>
+        /// Is it a stored proc or a batch?
+        /// </summary>
         public CommandType? CommandType { get; set; }
 
+        /// <summary>
+        /// Whether to buffer the results in memory.
+        /// </summary>
         public bool Buffered { get; set; } = true;
     }
 }

--- a/Dapper.GraphQL/SqlOptions.cs
+++ b/Dapper.GraphQL/SqlOptions.cs
@@ -1,0 +1,14 @@
+using System.Data;
+
+namespace Dapper.GraphQL
+{
+    public class SqlOptions {
+        public static readonly SqlOptions DefaultOptions = new SqlOptions();
+
+        public int? CommandTimeout { get; set; }
+
+        public CommandType? CommandType { get; set; }
+
+        public bool Buffered { get; set; } = true;
+    }
+}


### PR DESCRIPTION
An attempt to address #15 by introducing the `SqlOptions` class, which can specify `CommandTimeout` and other optional parameters to Dapper's execution methods.

I am not super happy about the name `SqlOptions`, maybe `CommandOptions` is better (and in line with `CommandTimeout`, etc.?).

Happy to add XML docs and other polish if you like the idea. 